### PR TITLE
Add domain file for Dhanalakshmi Srinivasan University (Perambalur)

### DIFF
--- a/file/lib/domains/in/edu/dsuniversity.txt
+++ b/file/lib/domains/in/edu/dsuniversity.txt
@@ -1,0 +1,1 @@
+Dhanalakshmi Srinivasan University, School of Engineering and Technology,Perambalur


### PR DESCRIPTION
Add domain file for Dhanalakshmi Srinivasan University, School of Engineering and Technology, Perambalur

Official Name: Dhanalakshmi Srinivasan University, School of Engineering and Technology, Perambalur

This PR adds the institution's domain as per the repository’s guidelines.